### PR TITLE
Add BigDecimal Formatter

### DIFF
--- a/src/main/java/cn/chenhuanming/octopus/formatter/BigDecimalFormatter.java
+++ b/src/main/java/cn/chenhuanming/octopus/formatter/BigDecimalFormatter.java
@@ -9,15 +9,19 @@ import java.math.BigDecimal;
 public class BigDecimalFormatter extends AbstractFormatter<BigDecimal> {
     @Override
     public BigDecimal parseImpl(String str) throws Exception {
-        if(str != null && !"".equals(str)) {
-            return new BigDecimal(str);
-        } else {
-            return null;
-        }
+        return new BigDecimal(str);
     }
 
     @Override
     public String format(BigDecimal bigDecimal) {
         return bigDecimal.toString();
+    }
+
+    static class PrimitiveFormatter extends BigDecimalFormatter {
+
+        @Override
+        protected BigDecimal defaultValueWhenParseEmpty() {
+            return null;
+        }
     }
 }

--- a/src/main/java/cn/chenhuanming/octopus/formatter/BigDecimalFormatter.java
+++ b/src/main/java/cn/chenhuanming/octopus/formatter/BigDecimalFormatter.java
@@ -16,12 +16,4 @@ public class BigDecimalFormatter extends AbstractFormatter<BigDecimal> {
     public String format(BigDecimal bigDecimal) {
         return bigDecimal.toString();
     }
-
-    static class PrimitiveFormatter extends BigDecimalFormatter {
-
-        @Override
-        protected BigDecimal defaultValueWhenParseEmpty() {
-            return null;
-        }
-    }
 }

--- a/src/main/java/cn/chenhuanming/octopus/formatter/BigDecimalFormatter.java
+++ b/src/main/java/cn/chenhuanming/octopus/formatter/BigDecimalFormatter.java
@@ -1,0 +1,23 @@
+package cn.chenhuanming.octopus.formatter;
+
+import java.math.BigDecimal;
+
+/**
+ * @author huiyadanli
+ * Created at 2019-06-22
+ */
+public class BigDecimalFormatter extends AbstractFormatter<BigDecimal> {
+    @Override
+    public BigDecimal parseImpl(String str) throws Exception {
+        if(str != null && !"".equals(str)) {
+            return new BigDecimal(str);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public String format(BigDecimal bigDecimal) {
+        return bigDecimal.toString();
+    }
+}

--- a/src/main/java/cn/chenhuanming/octopus/formatter/DefaultFormatterContainer.java
+++ b/src/main/java/cn/chenhuanming/octopus/formatter/DefaultFormatterContainer.java
@@ -29,7 +29,7 @@ public class DefaultFormatterContainer implements FormatterContainer {
         formatMap.put(Boolean.TYPE, new BooleanFormatter.PrimitiveFormatter());
         formatMap.put(Short.class, new ShortFormatter());
         formatMap.put(Short.TYPE, new ShortFormatter.PrimitiveFormatter());
-        formatMap.put(BigDecimal.class,new BigDecimalFormatter());
+        formatMap.put(BigDecimal.class,new BigDecimalFormatter.PrimitiveFormatter());
     }
 
     public <T> void addFormat(Class<T> clazz, Formatter<T> formatter) {

--- a/src/main/java/cn/chenhuanming/octopus/formatter/DefaultFormatterContainer.java
+++ b/src/main/java/cn/chenhuanming/octopus/formatter/DefaultFormatterContainer.java
@@ -2,6 +2,7 @@ package cn.chenhuanming.octopus.formatter;
 
 import lombok.EqualsAndHashCode;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class DefaultFormatterContainer implements FormatterContainer {
         formatMap.put(Boolean.TYPE, new BooleanFormatter());
         formatMap.put(Short.class, new ShortFormatter());
         formatMap.put(Short.TYPE, new ShortFormatter());
-
+        formatMap.put(BigDecimal.class,new BigDecimalFormatter());
     }
 
     public <T> void addFormat(Class<T> clazz, Formatter<T> formatter) {

--- a/src/main/java/cn/chenhuanming/octopus/formatter/DefaultFormatterContainer.java
+++ b/src/main/java/cn/chenhuanming/octopus/formatter/DefaultFormatterContainer.java
@@ -29,7 +29,7 @@ public class DefaultFormatterContainer implements FormatterContainer {
         formatMap.put(Boolean.TYPE, new BooleanFormatter.PrimitiveFormatter());
         formatMap.put(Short.class, new ShortFormatter());
         formatMap.put(Short.TYPE, new ShortFormatter.PrimitiveFormatter());
-        formatMap.put(BigDecimal.class,new BigDecimalFormatter.PrimitiveFormatter());
+        formatMap.put(BigDecimal.class,new BigDecimalFormatter());
     }
 
     public <T> void addFormat(Class<T> clazz, Formatter<T> formatter) {


### PR DESCRIPTION
Excel导入导出应用中，出现小数的情况下一般会用 `BigDecimal` ，不丢失精度。
实际运用中 BigDecimal 比 float、double 要更加常用些。